### PR TITLE
Link artifacts with imports and related

### DIFF
--- a/marmolada/database/main.py
+++ b/marmolada/database/main.py
@@ -1,8 +1,10 @@
 import pathlib
 from copy import deepcopy
+from typing import Any
 
 from sqlalchemy import MetaData
 from sqlalchemy import types as sqla_types
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
@@ -23,6 +25,7 @@ metadata = MetaData(naming_convention=naming_convention)
 type_annotation_map = {
     str: sqla_types.UnicodeText(),
     pathlib.Path: types.Path(),
+    dict[str, Any]: JSONB(),
 }
 
 

--- a/marmolada/database/main.py
+++ b/marmolada/database/main.py
@@ -1,11 +1,14 @@
+import pathlib
 from copy import deepcopy
 
 from sqlalchemy import MetaData
+from sqlalchemy import types as sqla_types
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from ..core.configuration import config
+from . import types
 
 # use custom metadata to specify naming convention
 naming_convention = {
@@ -17,9 +20,15 @@ naming_convention = {
 }
 metadata = MetaData(naming_convention=naming_convention)
 
+type_annotation_map = {
+    str: sqla_types.UnicodeText(),
+    pathlib.Path: types.Path(),
+}
+
 
 class Base(DeclarativeBase):
     metadata = metadata
+    type_annotation_map = type_annotation_map
 
 
 session_maker = sessionmaker(class_=AsyncSession, expire_on_commit=False, future=True)

--- a/marmolada/database/model/__init__.py
+++ b/marmolada/database/model/__init__.py
@@ -1,1 +1,1 @@
-from .artifact import Artifact
+from .artifact import Artifact, ImportBucket

--- a/marmolada/database/model/artifact.py
+++ b/marmolada/database/model/artifact.py
@@ -5,7 +5,7 @@ import pathlib
 from collections import defaultdict
 from typing import Any, ClassVar
 
-from sqlalchemy import Text, event
+from sqlalchemy import event
 from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, Session, mapped_column, object_session
@@ -14,7 +14,6 @@ from sqlalchemy.sql import SQLColumnExpression
 from ...core.configuration import config
 from .. import Base
 from ..mixins import Creatable, Updatable, UuidPrimaryKey
-from ..types import Path
 
 log = logging.getLogger(__name__)
 
@@ -31,10 +30,11 @@ class Artifact(Base, UuidPrimaryKey, Creatable, Updatable):
     _sessions_added_files: ClassVar = defaultdict(set)
     _sessions_removed_files: ClassVar = defaultdict(set)
 
-    content_type: Mapped[str] = mapped_column(Text, nullable=False)
+    content_type: Mapped[str]
+
     # Default for _path set in artifact_path_init() below
     _path: Mapped[pathlib.Path] = mapped_column(
-        "path", Path, unique=True, nullable=False, default=_artifact_path_default
+        "path", unique=True, nullable=False, default=_artifact_path_default
     )
 
     artifacts_root: ClassVar[pathlib.Path | None] = None


### PR DESCRIPTION
```
commit 17f2131ecd7304802d575181e4f1913f7e9a31c8
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Thu Feb 22 19:10:25 2024 +0100

    Use PEP 484 type annotations for database columns
    
    See:
    https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html#using-annotated-declarative-table-type-annotated-forms-for-mapped-column
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>

commit 77418ec6448c3409a9ded945d37db5c0620dbbfd
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Thu Feb 22 20:13:16 2024 +0100

    Add ImportBucket and link to Artifact
    
    In the course, add Artifact.source_uri and Artifact.file_name.
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>
```