### PR TITLE
Fix configuring through environment variables

### DIFF
--- a/marmolada/core/cli.py
+++ b/marmolada/core/cli.py
@@ -7,7 +7,7 @@ import click_plugins
 
 from . import configuration
 
-DEFAULT_CONFIG_FILE = "/etc/marmolada/config.yaml"
+DEFAULT_CONFIG_FILE = Path("/etc/marmolada/config.yaml")
 
 
 @click_plugins.with_plugins(entry_points(group="marmolada.cli"))
@@ -27,12 +27,9 @@ def cli(ctx: click.Context, config_paths: tuple[Path], debug: bool):
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
 
-    if not config_paths:
-        try:
-            configuration.read_configuration(DEFAULT_CONFIG_FILE, clear=True, validate=True)
-        except FileNotFoundError:
-            pass
-    else:
-        configuration.read_configuration(*config_paths, clear=True, validate=True)
+    if not config_paths and DEFAULT_CONFIG_FILE.exists():
+        config_paths = (DEFAULT_CONFIG_FILE,)
+
+    configuration.read_configuration(*config_paths)
 
     logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)

--- a/marmolada/core/configuration/main.py
+++ b/marmolada/core/configuration/main.py
@@ -23,7 +23,7 @@ def _expand_normalize_config_files(config_files: list[Path | str]) -> list[Path]
     return config_file_paths
 
 
-def read_configuration(*config_files: list[Path | str], clear: bool = True, validate: bool = True):
+def read_configuration(*config_files: list[Path | str]):
     config_files = _expand_normalize_config_files(config_files)
     new_config = {}
     for config_file in config_files:
@@ -31,15 +31,9 @@ def read_configuration(*config_files: list[Path | str], clear: bool = True, vali
             for config_doc in yaml.safe_load_all(fp):
                 new_config = merge_dicts(new_config, config_doc)
 
-    if validate:
-        # validate merged configuration
-        ConfigModel(**new_config)
-
-    new_config = merge_dicts(
-        new_config, ConfigModel().model_dump(exclude_unset=True, exclude_defaults=True)
+    new_config = ConfigModel.model_validate(new_config).model_dump(
+        exclude_unset=True, exclude_defaults=True, mode="json"
     )
 
-    if clear:
-        config.clear()
-
+    config.clear()
     config.update(new_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def marmolada_config(marmolada_config_files, tmp_path, request):
     @pytest.mark.marmolada_config(...) (see marmolada_config_files) and applies
     them in marmolada.core.configuration.config.
     """
-    read_configuration(*marmolada_config_files, clear=True)
+    read_configuration(*marmolada_config_files)
 
     # Optionally, override artifacts root path with a temporary, empty one for tests.
     tweak_for_tests = True

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -8,7 +9,8 @@ from marmolada.core import cli
 @pytest.fixture(autouse=True)
 def dont_read_system_config_file(tmp_path):
     with mock.patch.object(cli, "DEFAULT_CONFIG_FILE"):
-        cli.DEFAULT_CONFIG_FILE = str(tmp_path / "marmolada-config.yml")
+        cli.DEFAULT_CONFIG_FILE = tmp_path / "marmolada-config.yml"
+        cli.DEFAULT_CONFIG_FILE.touch()
         yield
 
 
@@ -24,9 +26,10 @@ class TestCLI:
     @mock.patch("marmolada.core.configuration.read_configuration")
     def test_init_config(self, read_configuration, testcase, tmp_path, cli_runner):
         args = ("test",)
+        mock_config_file = nullcontext()
         match testcase:
             case "without-config":
-                read_configuration.side_effect = FileNotFoundError
+                mock_config_file = mock.patch.object(cli, "DEFAULT_CONFIG_FILE")
             case "with-default-config":
                 pass
             case "with-config":
@@ -35,17 +38,21 @@ class TestCLI:
                 args = ("-c", str(tmp_path / "this doesn’t exist"), *args)
                 read_configuration.side_effect = FileNotFoundError
 
-        result = cli_runner.invoke(cli.cli, args)
+        with mock_config_file as mocked_config_file:
+            if isinstance(mocked_config_file, mock.Mock):
+                mocked_config_file.exists.return_value = False
+            result = cli_runner.invoke(cli.cli, args)
 
         match testcase:
-            case "without-config" | "with-default-config":
+            case "without-config":
                 assert result.exit_code == 0
-                read_configuration.assert_called_once_with(
-                    cli.DEFAULT_CONFIG_FILE, clear=True, validate=True
-                )
+                read_configuration.assert_called_once_with()
+            case "with-default-config":
+                assert result.exit_code == 0
+                read_configuration.assert_called_once_with(cli.DEFAULT_CONFIG_FILE)
             case "with-config":
                 assert result.exit_code == 0
-                read_configuration.assert_called_once_with("/dev/null", clear=True, validate=True)
+                read_configuration.assert_called_once_with("/dev/null")
             case "with-missing-config":
                 assert result.exit_code != 0
                 read_configuration.assert_not_called()

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -2,7 +2,6 @@ import copy
 from pathlib import Path
 
 import pytest
-import yaml
 
 from marmolada.core.configuration import main
 from marmolada.core.util import merge_dicts
@@ -28,13 +27,9 @@ class TestConfiguration:
         assert expanded_config_files == [*marmolada_config_files, sub_file1, sub_file2]
 
     @pytest.mark.marmolada_config(tweak_for_tests=False)
-    @pytest.mark.parametrize("clear", (True, False))
-    def test_read_configuration_clear(self, clear, marmolada_config_files):
-        main.read_configuration(clear=clear)
-        if clear:
-            assert all(value is None for value in main.config.values())
-        else:
-            assert main.config == EXAMPLE_CONFIG
+    def test_read_configuration_clear(self, marmolada_config_files):
+        main.read_configuration()
+        assert all(value is None for value in main.config.values())
 
     @pytest.mark.marmolada_config({}, objtype=str, clear=False)
     def test_read_configuration_str(self, marmolada_config_files):
@@ -55,16 +50,6 @@ class TestConfiguration:
     @pytest.mark.marmolada_config({"api": {}})
     def test_read_configuration_partial(self, marmolada_config_files, tmp_path):
         assert main.config == EXAMPLE_CONFIG
-
-    @pytest.mark.marmolada_config(example_config=True, clear=True)
-    def test_read_configuration_partial_validate_post(self, marmolada_config_files, tmp_path):
-        partial_config_file = tmp_path / "partial-config.yaml"
-        with partial_config_file.open("w") as fp:
-            yaml.dump({"metaclient": {}}, fp)
-
-        main.read_configuration(partial_config_file, clear=True, validate=False)
-        main.read_configuration(*marmolada_config_files, clear=False, validate=False)
-        main.read_configuration(clear=False, validate=True)
 
     @pytest.mark.marmolada_config("API__HOST=BOO", objtype="env", clear=True)
     def test_read_configuration_from_env(self, marmolada_config_files):


### PR DESCRIPTION
Previously, environment variables were only processed if a configuration file was specified which is especially annoying for its main use case: passing configuration into containers.

In the course, simplify processing configuration files and remove unused functionality.

Related: #296