### PR TITLE
Allow database setup not to be fatal

### DIFF
--- a/marmolada/database/cli.py
+++ b/marmolada/database/cli.py
@@ -10,9 +10,14 @@ def database() -> None:
 
 
 @database.command()
-def setup() -> None:
+@click.option(
+    "--existing-ok/--existing-fatal",
+    default=False,
+    help="If tables existing in the database should cause a non-zero exit code.",
+)
+def setup(existing_ok: bool) -> None:
     """Create tables from the database model."""
-    setup_db_schema()
+    setup_db_schema(existing_ok=existing_ok)
 
 
 @database.group()

--- a/marmolada/database/setup.py
+++ b/marmolada/database/setup.py
@@ -14,17 +14,20 @@ from .main import metadata
 HERE = Path(__file__).parent
 
 
-def setup_db_schema() -> None:
+def setup_db_schema(existing_ok: bool = False) -> None:
     engine = create_engine(**config["database"]["sqlalchemy"])
 
     inspection_result = inspect(engine)
 
-    present_tables = sorted(n for n in metadata.tables if inspection_result.has_table(n))
+    present_tables = sorted(inspection_result.get_table_names())
 
     if present_tables:
-        print(f"Tables already present: {', '.join(present_tables)}", file=sys.stderr)
-        print("Refusing to change database schema.", file=sys.stderr)
-        sys.exit(1)
+        print(
+            f"Tables already present: {', '.join(present_tables)}\n"
+            + "Refusing to change database schema.",
+            file=sys.stdout if existing_ok else sys.stderr,
+        )
+        sys.exit(0 if existing_ok else 1)
 
     with engine.begin():
         print("Creating database schema")

--- a/tests/database/test_cli.py
+++ b/tests/database/test_cli.py
@@ -10,7 +10,7 @@ def test_setup(setup_db_schema, cli_runner):
 
     assert result.exit_code == 0
 
-    setup_db_schema.assert_called_once_with()
+    setup_db_schema.assert_called_once_with(existing_ok=False)
 
 
 @mock.patch.object(cli, "alembic_migration")

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -6,17 +6,24 @@ import pytest
 from marmolada.database import setup
 
 
-@pytest.mark.parametrize("db_empty", (True, False), ids=("db-empty", "db-not-empty"))
+@pytest.mark.parametrize(
+    "db_empty, existing_ok",
+    (
+        (True, False),
+        (False, False),
+        (False, True),
+    ),
+    ids=("db-empty", "db-not-empty-existing-fatal", "db-not-empty-existing-ok"),
+)
 @mock.patch.dict("marmolada.database.setup.config")
 @mock.patch("marmolada.database.setup.alembic")
 @mock.patch("marmolada.database.setup.metadata")
 @mock.patch("marmolada.database.setup.inspect")
 @mock.patch("marmolada.database.setup.create_engine")
-def test_setup_db_schema(create_engine, inspect, metadata, alembic, db_empty, capsys):
+def test_setup_db_schema(create_engine, inspect, metadata, alembic, db_empty, existing_ok, capsys):
     create_engine.return_value = engine = mock.MagicMock()
     inspection_result = inspect.return_value
-    inspection_result.has_table.return_value = not db_empty
-    metadata.tables = ["boo"]
+    inspection_result.get_table_names.return_value = [] if db_empty else ["boo"]
     alembic_cfg = alembic.config.Config.return_value
     setup.config["database"] = {"sqlalchemy": {"url": "boo"}}
 
@@ -25,17 +32,21 @@ def test_setup_db_schema(create_engine, inspect, metadata, alembic, db_empty, ca
     else:
         expectation = pytest.raises(SystemExit)
 
-    with expectation:
-        setup.setup_db_schema()
+    with expectation as excinfo:
+        setup.setup_db_schema(existing_ok=existing_ok)
 
     if db_empty:
         metadata.create_all.assert_called_with(bind=engine)
         assert alembic_cfg.set_main_option.call_count > 0
         alembic.command.stamp.assert_called_once_with(alembic_cfg, "head")
     else:
+        assert excinfo.value.code == 0 if existing_ok else 1
+
         stdout, stderr = capsys.readouterr()
-        assert "Tables already present: boo\n" in stderr
-        assert "Refusing to change database schema." in stderr
+        output = stdout if existing_ok else stderr
+
+        assert "Tables already present: boo\n" in output
+        assert "Refusing to change database schema." in output
 
         metadata.create_all.assert_not_called()
         alembic_cfg.set_main_option.assert_not_called()


### PR DESCRIPTION
When running in a single-use container, this avoids interpreting the exit code as “something has failed”.

Related: #250