### PR TITLE
Refactor DB model primary keys

### DIFF
--- a/marmolada/api/artifacts.py
+++ b/marmolada/api/artifacts.py
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/artifacts")
 def _get_artifacts_query(import_uuid: UUID | None = None) -> Select:
     query = select(Artifact).order_by(Artifact.created_at).options(selectinload(Artifact.import_))
     if import_uuid:
-        query = query.filter_by(import_uuid=import_uuid)
+        query = query.join(Artifact.import_.and_(Import.uuid == import_uuid))
     return query
 
 

--- a/marmolada/database/mixins.py
+++ b/marmolada/database/mixins.py
@@ -2,7 +2,7 @@ import datetime as dt
 from typing import Any
 from uuid import UUID, uuid1
 
-from sqlalchemy import Uuid
+from sqlalchemy import BigInteger, Identity, Uuid
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, QueryableAttribute, mapped_column
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Mapped, QueryableAttribute, mapped_column
 from .types.tzdatetime import TZDateTime
 from .util import utcnow
 
-__all__ = ("Creatable", "Updatable", "UuidPrimaryKey")
+__all__ = ("BigIntPrimaryKey", "Creatable", "Updatable", "UuidAltKey")
 
 
 class Creatable:
@@ -23,8 +23,12 @@ class Updatable:
     )
 
 
-class UuidPrimaryKey:
-    _uuid: Mapped[UUID] = mapped_column("uuid", Uuid, primary_key=True, default=uuid1)
+class BigIntPrimaryKey:
+    id: Mapped[BigInteger] = mapped_column("id", BigInteger, Identity(), primary_key=True)
+
+
+class UuidAltKey:
+    _uuid: Mapped[UUID] = mapped_column("uuid", Uuid, unique=True, default=uuid1, nullable=False)
 
     @hybrid_property
     def uuid(self) -> UUID:
@@ -41,7 +45,7 @@ class UuidPrimaryKey:
         return cls._uuid
 
 
-@listens_for(UuidPrimaryKey, "init", propagate=True)
-def uuid_primary_key_init(target: UuidPrimaryKey, args: tuple[Any], kwargs: dict[str, Any]) -> None:
+@listens_for(UuidAltKey, "init", propagate=True)
+def uuid_primary_key_init(target: UuidAltKey, args: tuple[Any], kwargs: dict[str, Any]) -> None:
     # Ensure uuid is available early
     kwargs["uuid"] = kwargs.get("uuid") or uuid1()

--- a/marmolada/database/model/task.py
+++ b/marmolada/database/model/task.py
@@ -1,28 +1,26 @@
-from uuid import UUID
-
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .. import Base
-from ..mixins import Creatable, UuidPrimaryKey
+from ..mixins import BigIntPrimaryKey, Creatable, UuidAltKey
 from .artifact import Artifact, Import
 
 
-class TaskMixin(Creatable, UuidPrimaryKey):
+class TaskMixin(BigIntPrimaryKey, UuidAltKey, Creatable):
     name: Mapped[str]
 
 
 class ArtifactTask(Base, TaskMixin):
     __tablename__ = "artifact_tasks"
-    __table_args__ = (UniqueConstraint("name", "artifact_uuid"),)
+    __table_args__ = (UniqueConstraint("name", "artifact_id"),)
 
-    artifact_uuid: Mapped[UUID] = mapped_column(ForeignKey(Artifact.uuid))
+    artifact_id: Mapped[int] = mapped_column(ForeignKey(Artifact.id))
     artifact: Mapped[Artifact] = relationship(back_populates="tasks")
 
 
 class ImportTask(Base, TaskMixin):
     __tablename__ = "import_tasks"
-    __table_args__ = (UniqueConstraint("name", "import_uuid"),)
+    __table_args__ = (UniqueConstraint("name", "import_id"),)
 
-    import_uuid: Mapped[UUID] = mapped_column(ForeignKey(Import.uuid))
+    import_id: Mapped[int] = mapped_column(ForeignKey(Import.id))
     import_: Mapped[Import] = relationship(back_populates="tasks")

--- a/tests/database/model/test_artifact.py
+++ b/tests/database/model/test_artifact.py
@@ -56,7 +56,11 @@ class TestArtifact(ModelTestBase):
 
     async def test_path_getter(self, db_obj: Artifact):
         assert db_obj._path == str(db_obj.path)
-        assert db_obj._path == f"incoming/{db_obj.import_.uuid!s}/{self.attrs['file_name']}"
+        uuid = db_obj.uuid
+        import_id = db_obj.import_.id
+        assert db_obj._path == (
+            f"incoming/import-{import_id}-artifact-{uuid}-{self.attrs['file_name']}"
+        )
 
     @pytest.mark.parametrize("test_type", (str, Path))
     async def test_path_setter(self, test_type: type, db_obj: Artifact, db_session: AsyncSession):

--- a/tests/database/test_mixins.py
+++ b/tests/database/test_mixins.py
@@ -9,7 +9,7 @@ from marmolada.database import mixins
 from marmolada.database.main import Base
 
 
-class Thing(Base, mixins.UuidPrimaryKey, mixins.Creatable, mixins.Updatable):
+class Thing(Base, mixins.BigIntPrimaryKey, mixins.UuidAltKey, mixins.Creatable, mixins.Updatable):
     __tablename__ = "things"
 
     something: Mapped[int] = mapped_column(nullable=True)
@@ -35,26 +35,24 @@ async def test_updating(db_session):
     then = dt.datetime.now(dt.UTC)
 
     async with db_session.begin():
-        thing = await db_session.get(Thing, thing.uuid, with_for_update=True)
+        thing = await db_session.get(Thing, thing.id, with_for_update=True)
         thing.something = 5
 
     then_again = dt.datetime.now(dt.UTC)
 
     async with db_session.begin():
-        thing = await db_session.get(
-            Thing, thing.uuid, populate_existing=True, with_for_update=True
-        )
+        thing = await db_session.get(Thing, thing.id, populate_existing=True, with_for_update=True)
         assert then <= thing.updated_at <= then_again
         thing.something = 6
 
     then_again_and_later = dt.datetime.now(dt.UTC)
 
     async with db_session.begin():
-        thing = await db_session.get(Thing, thing.uuid, populate_existing=True)
+        thing = await db_session.get(Thing, thing.id, populate_existing=True)
         assert then_again <= thing.updated_at <= then_again_and_later
 
 
-class TestUuidMixin:
+class TestUuidAltKey:
     async def test_instance_attribute(self, db_session):
         async with db_session.begin():
             thing = Thing()


### PR DESCRIPTION
Use BigInteger columns as primary and foreign keys, relegate uuid to be an alternate key.

Fixes: #333